### PR TITLE
explicit cast to integer for headroom

### DIFF
--- a/omics/cli/run_analyzer/__main__.py
+++ b/omics/cli/run_analyzer/__main__.py
@@ -336,7 +336,7 @@ def add_metrics(res, resources, pricing, headroom=0.0):
     rtype = arn[-2]
     region = arn[3]
     res["type"] = rtype
-    headroom_multiplier = 1 + headroom
+    headroom_multiplier = 1 + int(headroom)
 
     metrics = res.get("metrics", {})
     # if a resource has no metrics body then we can skip the rest


### PR DESCRIPTION
defends agains headroom being processed as a string


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
