### PR TITLE
fix(run-analyzer): eliminate instance type duplication and extend 48x…

### DIFF
--- a/omics/cli/run_analyzer/utils.py
+++ b/omics/cli/run_analyzer/utils.py
@@ -54,6 +54,30 @@ _sizes = {
 }
 _families = {"c": 2, "m": 4, "r": 8, "g4dn": 16, "g5": 16, "g6": 16, "g6e": 32}
 
+# Non-GPU families for instance selection (used by run analyzer)
+_compute_families = {"c": 2, "m": 4, "r": 8}
+
+
+def get_instance_for_requirements(cpus, mem):
+    """Return a tuple of smallest matching instance type (str), cpus in that type (int), GiB memory of that type (int)
+
+    Returns empty tuple if no suitable instance is found (requirements exceed largest available instance).
+    """
+    supported_sizes = list(_sizes.keys())
+
+    for size in supported_sizes:
+        ccount = _sizes[size]
+        if ccount < cpus:
+            continue
+        for fam in sorted(_compute_families, key=lambda x: _compute_families[x]):
+            mcount = ccount * _compute_families[fam]
+            if mcount < mem:
+                continue
+            return (f"omics.{fam}.{size}", ccount, mcount)
+
+    # Return empty tuple instead of empty string to avoid unpacking errors
+    return ()
+
 
 def omics_instance_weight(instance: str) -> int:
     """Compute a numeric weight for an instance to be used in sorting or finding a max or min"""


### PR DESCRIPTION
…large support

- Consolidate instance size and family definitions in utils.py as single source of truth
- Remove duplicate instance type mappings from main.py
- Add support for 48xlarge instances (previously limited to 24xlarge)
- Fix ValueError when no suitable instance found by returning empty tuple instead of empty string
- Add detailed error logging to stderr when requirements exceed largest available instance
- Add comprehensive test coverage for all instance selection scenarios including edge cases

Resolves issue where run analyzer would crash with 'ValueError: not enough values to unpack' when encountering tasks with requirements exceeding available instance types.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
