### PR TITLE
deps: group Dependabot updates into sensible categories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,25 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    groups:
+      aws-sdk:
+        patterns:
+          - "boto*"
+          - "mypy-boto3-*"
+      dev-dependencies:
+        patterns:
+          - "pytest*"
+          - "mypy"
+          - "black"
+          - "flake8"
+          - "coverage"
+          - "tox"
+      data-processing:
+        patterns:
+          - "pandas"
+          - "numpy"
+          - "bokeh"
+          - "jinja2"
 
   # Enable security updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -26,3 +45,7 @@ updates:
     labels:
       - "github-actions"
       - "security"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
*Description of changes:*

groups dependabot updates by type to reduce the number of PRs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
