### PR TITLE
rerun: support nested --parameter overrides

### DIFF
--- a/omics/cli/rerun/__main__.py
+++ b/omics/cli/rerun/__main__.py
@@ -42,7 +42,7 @@ Options:
  --cache-behavior <value>               Override original run parameter, CACHE_ON_FAILURE or CACHE_ALWAYS
  --run-group-id=<id>                    Override original run parameter
  --priority=<priority>                  Override original run parameter
- --parameter=<key=value>...             Override original run parameter
+ --parameter=<key=value>...             Override original run parameter (dot-path keys set nested values)
  --storage-capacity=<value>             Override original run parameter
  --storage-type=<value>                 Override original run parameter, DYNAMIC or STATIC
  --workflow-owner-id=<value>            Override original run parameter, required for shared workflows
@@ -63,6 +63,7 @@ Examples:
  omics-rerun -d 1234567
 """
 
+import copy
 import datetime
 import json
 import os
@@ -81,6 +82,21 @@ exename = os.path.basename(sys.argv[0])
 def die(msg):
     """Show error message and terminate"""
     exit(f"{exename}: {msg}")
+
+
+def _set_nested(params, path, value):
+    """Set params[a][b][c] = value, walking/creating dicts along the dot-path."""
+    segments = path.split(".")
+    cursor = params
+    for seg in segments[:-1]:
+        nxt = cursor.get(seg)
+        if not isinstance(nxt, dict):
+            if seg in cursor:
+                die(f"--parameter path {path!r}: {seg!r} is not an object")
+            nxt = {}
+            cursor[seg] = nxt
+        cursor = nxt
+    cursor[segments[-1]] = value
 
 
 def stream_to_run(strm):
@@ -231,14 +247,14 @@ def start_run_request(run, opts={}):
     if "priority" in rqst:
         rqst["priority"] = int(rqst["priority"])
     if run.get("parameters"):
-        rqst["parameters"] = run["parameters"]
+        rqst["parameters"] = copy.deepcopy(run["parameters"])
     for p in (opts or {}).get("--parameter", []):
-        m = re.match(r"^(\w+)=(\w+)", p)
-        if not m:
+        if "=" not in p:
             die(f"invalid --parameter: {p} (expecting <key>=<value>)")
+        key, _, value = p.partition("=")
         if "parameters" not in rqst:
             rqst["parameters"] = {}
-        rqst["parameters"][m.group(1)] = m.group(2)
+        _set_nested(rqst["parameters"], key, value)
     if rqst["workflowType"] != "READY2RUN":
         if opts.get("--storage-capacity") or run.get("storageCapacity"):
             set_param(rqst, "storageCapacity", "--storage-capacity")

--- a/tests/cli/rerun/test_parameters.py
+++ b/tests/cli/rerun/test_parameters.py
@@ -1,0 +1,127 @@
+"""Tests for --parameter handling in `aws-healthomics-tools rerun`."""
+
+import copy
+import unittest
+
+from omics.cli.rerun.__main__ import _set_nested, start_run_request
+
+
+def _make_run(parameters=None):
+    run = {
+        "arn": "arn:aws:omics:us-west-2:1234:run/7777",
+        "workflow": "arn:aws:omics:us-west-2:1234:workflow/5678",
+    }
+    if parameters is not None:
+        run["parameters"] = parameters
+    return run
+
+
+def _opts(**overrides):
+    defaults = {
+        "--workflow-id": None,
+        "--workflow-version-name": None,
+        "--workflow-type": None,
+        "--run-id": None,
+        "--role-arn": None,
+        "--name": None,
+        "--cache-id": None,
+        "--cache-behavior": None,
+        "--run-group-id": None,
+        "--priority": None,
+        "--parameter": [],
+        "--storage-capacity": None,
+        "--storage-type": None,
+        "--workflow-owner-id": None,
+        "--retention-mode": None,
+        "--output-uri": None,
+        "--log-level": None,
+        "--tag": [],
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+class TestSetNested(unittest.TestCase):
+    def test_flat_key(self):
+        params = {}
+        _set_nested(params, "foo", "bar")
+        self.assertEqual(params, {"foo": "bar"})
+
+    def test_nested_creates_intermediates(self):
+        params = {}
+        _set_nested(params, "a.b.c", "X")
+        self.assertEqual(params, {"a": {"b": {"c": "X"}}})
+
+    def test_nested_preserves_siblings(self):
+        params = {"a": {"b": {"c": "Y", "d": "Z"}}}
+        _set_nested(params, "a.b.c", "X")
+        self.assertEqual(params, {"a": {"b": {"c": "X", "d": "Z"}}})
+
+    def test_scalar_conflict_dies(self):
+        params = {"a": "scalar"}
+        with self.assertRaises(SystemExit):
+            _set_nested(params, "a.b", "X")
+
+
+class TestParameterOverride(unittest.TestCase):
+    def test_flat_override_preserves_full_uri(self):
+        run = _make_run({"foo": "old"})
+        uri = "s3://bucket/path:with/colons-and.dots-and-dashes"
+        rqst = start_run_request(run, _opts(**{"--parameter": [f"foo={uri}"]}))
+        self.assertEqual(rqst["parameters"]["foo"], uri)
+
+    def test_nested_override_preserves_siblings(self):
+        run = _make_run(
+            {
+                "docker_images": {
+                    "aligner": "old:aligner-v1",
+                    "caller": "keep:caller-v1",
+                }
+            }
+        )
+        new_img = "123456789012.dkr.ecr.us-west-2.amazonaws.com/tools:aligner-v2"
+        rqst = start_run_request(
+            run,
+            _opts(**{"--parameter": [f"docker_images.aligner={new_img}"]}),
+        )
+        self.assertEqual(
+            rqst["parameters"],
+            {"docker_images": {"aligner": new_img, "caller": "keep:caller-v1"}},
+        )
+
+    def test_nested_override_creates_missing_intermediates(self):
+        run = _make_run({"existing": "ok"})
+        rqst = start_run_request(
+            run,
+            _opts(**{"--parameter": ["new.nested.key=val"]}),
+        )
+        self.assertEqual(
+            rqst["parameters"],
+            {"existing": "ok", "new": {"nested": {"key": "val"}}},
+        )
+
+    def test_does_not_mutate_source_run(self):
+        source = {"docker_images": {"aligner": "old:v1"}}
+        run = _make_run(copy.deepcopy(source))
+        start_run_request(
+            run,
+            _opts(**{"--parameter": ["docker_images.aligner=new:v2"]}),
+        )
+        self.assertEqual(run["parameters"], source)
+
+    def test_missing_equals_dies(self):
+        run = _make_run({"foo": "old"})
+        with self.assertRaises(SystemExit):
+            start_run_request(run, _opts(**{"--parameter": ["no_equals_here"]}))
+
+    def test_value_containing_equals_preserved(self):
+        run = _make_run({"foo": "old"})
+        rqst = start_run_request(
+            run,
+            _opts(**{"--parameter": ["foo=a=b=c"]}),
+        )
+        self.assertEqual(rqst["parameters"]["foo"], "a=b=c")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #275.

### What changed

`omics-rerun --parameter <key>=<value>` now accepts dot-path keys so a single nested leaf value can be overridden.
```
aws-healthomics-tools rerun <RUN_ID> \
  --parameter docker_images.aligner=123456789012.dkr.ecr.us-west-2.amazonaws.com/tools:aligner-v2
```
Given an existing parameters like:
```
{"docker_images": {"aligner": "…:aligner-old", "caller": "…:caller-v1"}}
```
the resulting StartRun request contains:
```
{"docker_images": {"aligner": "…/tools:aligner-v2", "caller": "…:caller-v1"}}
```
— the targeted leaf is replaced and sibling keys are preserved.

### Implementation

- New `_set_nested(params, path, value)` helper walks `path.split(".")`, creating intermediate dicts as needed. If an intermediate key already exists as a non-dict scalar, the helper errors out via `die()` rather than silently clobbering it.
- start_run_request now deep-copies the source `run["parameters"]` before applying overrides, so the fetched dict is not mutated in place.
- Parameter parsing switched from `re.match(r"^(\w+)=(\w+)", p)` to `str.partition("=")` for robust parsing of non-word characters
- Docopt help for `--parameter` updated to note dot-path support.
- Backwards compatible: flat `--parameter foo=bar` behaves exactly as before.

Testing

- `poetry run pytest` — full suite passes (10 new + 88 existing tests).
- Dry-run verified against a real nested parameter structure: only the targeted leaf changes in the printed StartRun request; siblings are preserved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.