### PR TITLE
ci: add TestPyPI publishing for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,27 @@ jobs:
       - name: Run lint & tests
         run: make ci
 
-  publish:
+  publish-testpypi:
+    if: github.event.release.prerelease
+    needs: ci
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install poetry
+        run: pip install --upgrade pip poetry
+      - name: Build package
+        run: poetry build
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: "!github.event.release.prerelease"
     needs: ci
     runs-on: ubuntu-latest
     environment: pypi


### PR DESCRIPTION
Splits the release workflow into two paths:

- **Pre-release** (e.g. `v0.13.2-rc1`) → publishes to TestPyPI
- **Full release** (e.g. `v0.13.2`) → publishes to PyPI prod

**Usage:**
```bash
# Test release
gh release create v0.13.2-rc1 --prerelease --generate-notes

# Verify on https://test.pypi.org/project/aws-healthomics-tools/

# Production release
gh release create v0.13.2 --generate-notes
```

**Additional setup required:**
- Create a `testpypi` environment in GitHub repo settings
- Add trusted publisher on [test.pypi.org](https://test.pypi.org/manage/project/aws-healthomics-tools/settings/publishing/) with workflow `release.yml` and environment `testpypi`